### PR TITLE
Spring boot 3.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ locations, plants, plant comments, and seed packages.
 1. Clone the repository:
     ```sh
     git clone https://github.com/marcusfromsweden/plant-doctor.git
+    git checkout spring-boot-3.4.2
     cd plant-doctor
     ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To run the Docker container, you must pass the environment variable SPRING_DATAS
 as there is no default value in application.properties. Use the following command:
 
 ```sh
-docker run -d --name plant-doctor -p 8080:8080 -e SPRING_DATASOURCE_PLANTDOCTOR_URL plantdoctor-app:latest
+docker run -d --name plant-doctor -p 8080:8080 -e SPRING_DATASOURCE_PLANTDOCTOR_URL plant-doctor:latest
 ```
 
 ## Docker Compose

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ locations, plants, plant comments, and seed packages.
 1. Clone the repository:
     ```sh
     git clone https://github.com/marcusfromsweden/plant-doctor.git
-    git checkout spring-boot-3.4.2
     cd plant-doctor
+    git checkout spring-boot-3.4.2
     ```
 
 2. Configure the database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:15
     container_name: postgres
     environment:
-      POSTGRES_DB: plant_doctor
+      POSTGRES_DB: plantdoctor
       POSTGRES_USER: plantdoctoradmin
       POSTGRES_PASSWORD: plantdoctoradminpassword
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-surefire-and-failsafe-plugin.version>3.1.2</maven-surefire-and-failsafe-plugin.version>
         <json-path.version>2.9.0</json-path.version>
-        <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0-RC1</springdoc-openapi.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <org.testcontainers.postgresql.version>1.20.4</org.testcontainers.postgresql.version>
@@ -110,12 +110,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Stupid dependency bug

## Summary by Sourcery

Updates dependencies and fixes configuration issues. This includes updating the springdoc-openapi version, correcting the scope of some dependencies, updating the database name in the Docker Compose configuration, and updating the docker run command in the README.

Bug Fixes:
- Fixes a dependency bug by updating the springdoc-openapi version to 2.7.0-RC1.
- Fixes a bug where jackson-databind and spring-tx dependencies were incorrectly scoped as test dependencies.

Build:
- Updates the springdoc-openapi version to 2.7.0-RC1.

Deployment:
- Updates the Docker Compose configuration to use 'plantdoctor' as the database name.
- Updates the docker run command in the README to use the correct image name 'plant-doctor:latest'.

Chores:
- Adds a checkout step to the README to checkout the spring-boot-3.4.2 branch.