### PR TITLE
Fixed stupid mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ To run the application, use the following command:
 mvn spring-boot:run
 ```
 
+To access the API, open a web browser and navigate to `http://localhost:8080/swagger-ui/index.html`.
+Here you can find the OpenAPI documentation for the application and try out the API.
+
 ## Docker
 
 You can run the application using Docker. A `Dockerfile` is provided to build the application image.
@@ -107,7 +110,7 @@ To run the Docker container, you must pass the environment variable SPRING_DATAS
 as there is no default value in application.properties. Use the following command:
 
 ```sh
-docker run -d --name plant-doctor -p 8080:8080 -e SPRING_DATASOURCE_PLANTDOCTOR_URL plantdoctor-app:latest
+docker run -d --name plant-doctor -p 8080:8080 -e SPRING_DATASOURCE_PLANTDOCTOR_URL plant-doctor:latest
 ```
 
 ## Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:15
     container_name: postgres
     environment:
-      POSTGRES_DB: plant_doctor
+      POSTGRES_DB: plantdoctor
       POSTGRES_USER: plantdoctoradmin
       POSTGRES_PASSWORD: plantdoctoradminpassword
     ports:
@@ -17,7 +17,7 @@ services:
     image: plant-doctor:latest
     container_name: spring_app
     environment:
-      SPRING_DATASOURCE_PLANTDOCTOR_URL: jdbc:postgresql://postgres:5432/plant_doctor
+      SPRING_DATASOURCE_PLANTDOCTOR_URL: jdbc:postgresql://postgres:5432/plantdoctor
       SPRING_DATASOURCE_PLANTDOCTOR_USERNAME: plantdoctoradmin
       SPRING_DATASOURCE_PLANTDOCTOR_PASSWORD: plantdoctoradminpassword
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-surefire-and-failsafe-plugin.version>3.1.2</maven-surefire-and-failsafe-plugin.version>
         <json-path.version>2.9.0</json-path.version>
-        <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0-RC1</springdoc-openapi.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <org.testcontainers.postgresql.version>1.20.4</org.testcontainers.postgresql.version>
@@ -110,12 +110,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/BotanicalSpeciesMapper.java
+++ b/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/BotanicalSpeciesMapper.java
@@ -23,7 +23,6 @@ public class BotanicalSpeciesMapper {
 
     public BotanicalSpecies toEntity(BotanicalSpeciesDTO botanicalSpeciesDetails) {
         BotanicalSpecies botanicalSpecies = new BotanicalSpecies();
-        botanicalSpecies.setId(botanicalSpeciesDetails.id());
         return toEntity(botanicalSpecies, botanicalSpeciesDetails);
     }
 

--- a/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/GrowingLocationMapper.java
+++ b/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/GrowingLocationMapper.java
@@ -21,7 +21,6 @@ public class GrowingLocationMapper {
 
     public GrowingLocation toEntity(GrowingLocationDTO growingLocationDTO) {
         GrowingLocation growingLocation = new GrowingLocation();
-        growingLocation.setId(growingLocationDTO.id());
         return toEntity(growingLocation, growingLocationDTO);
     }
 

--- a/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/PlantCommentMapper.java
+++ b/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/PlantCommentMapper.java
@@ -31,7 +31,6 @@ public class PlantCommentMapper {
 
     public PlantComment toEntity(PlantCommentDTO plantCommentDTO) {
         PlantComment plantComment = new PlantComment();
-        plantComment.setId(plantCommentDTO.id());
         return toEntity(plantComment, plantCommentDTO);
     }
 

--- a/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/PlantMapper.java
+++ b/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/PlantMapper.java
@@ -35,7 +35,6 @@ public class PlantMapper {
 
     public Plant toEntity(PlantDTO plantDTO) {
         Plant plant = new Plant();
-        plant.setId(plantDTO.id());
         return toEntity(plant, plantDTO);
     }
 

--- a/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/SeedPackageMapper.java
+++ b/src/main/java/com/marcusfromsweden/plantdoctor/dto/mapper/SeedPackageMapper.java
@@ -26,7 +26,6 @@ public class SeedPackageMapper {
 
     public SeedPackage toEntity(SeedPackageDTO seedPackageDTO) {
         SeedPackage seedPackage = new SeedPackage();
-        seedPackage.setId(seedPackageDTO.id());
         return toEntity(seedPackage, seedPackageDTO);
     }
 


### PR DESCRIPTION
## Summary by Sourcery

This pull request fixes a bug in the DTO mappers, updates the Springdoc OpenAPI version, updates the Docker configuration, and removes unnecessary dependencies.

Bug Fixes:
- Fixes a bug where DTO mappers were incorrectly setting the ID on new entities, which is the responsibility of the database.

Enhancements:
- Updates the Springdoc OpenAPI version to 2.7.0-RC1.
- Adds instructions to access the OpenAPI documentation via Swagger UI.

Build:
- Updates the Docker image tag in the `docker run` command in the README.
- Corrects the database name in the Docker Compose file.

Chores:
- Removes unnecessary test scope from `jackson-databind` and `spring-tx` dependencies in `pom.xml`.